### PR TITLE
enforce character type for character columns

### DIFF
--- a/R/product.R
+++ b/R/product.R
@@ -23,10 +23,10 @@ product <- function(product_id) {
     content(as = "text", encoding = "UTF-8") %>%
     fromJSON()
 
-  if (is.null(result$brand)) result$brand = NA
-  if (is.null(result$model)) result$model = NA
-  if (is.null(result$sku)) result$sku = NA
-  if (!length(result$barcodes)) result$barcodes = NA
+  if (is.null(result$brand)) result$brand = NA_character_
+  if (is.null(result$model)) result$model = NA_character_
+  if (is.null(result$sku)) result$sku = NA_character_
+  if (!length(result$barcodes)) result$barcodes = NA_character_
 
   result %>%
     as_tibble() %>%

--- a/tests/testthat/test-3-product.R
+++ b/tests/testthat/test-3-product.R
@@ -22,11 +22,11 @@ test_that("product prices (correct columns)", {
 test_that("brand is NULL", {
   product_null_brand <- product(product_id_null_brand)
 
-  expect_equal(product_null_brand$brand, NA)
+  expect_equal(product_null_brand$brand, NA_character_)
 })
 
 test_that("sku is NULL", {
   product_null_sku <- product(product_id_null_sku)
 
-  expect_equal(product_null_sku$sku, NA)
+  expect_equal(product_null_sku$sku, NA_character_)
 })


### PR DESCRIPTION
Some of the products in a given retailer have null, while others don't. I see that you treated for this case, but under certain combination of retailer & product, as_tibble() will covert columns as logical when it is actually character. 

I can only guess that these are characters from experimenting with the API and failing to combine product tibbles due to type mismatch. These types should match with whatever DB types are. Let me know if these are incorrect & feel free to edit them.

--
I actually would suggest creating an empty tibble with strict column type definition and `bind_rows()` to it in all your API calls (including `paginate(...)`) I found this to be the safest way to enforce types. Ideally, the tibble column types I receive from an API request should consistently be the same type, regardless of missing data. It tells API contracts are very helpful to the API consumer